### PR TITLE
Idempotent fetch and --force option

### DIFF
--- a/bin/bashvm-fetch
+++ b/bin/bashvm-fetch
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 fetch() {
+  if [[ -d "$BASHVM_HOME/src/bash-${1}" ]]; then
+    echo "The source of bash-${1} is already exists"
+    return 0
+  fi
+
   tmpfile=$(mktemp)
   echo "Fetching bash-${1}..."
   curl -o"$tmpfile"  --progress-bar "ftp://ftp.gnu.org/gnu/bash/bash-${1}.tar.gz" || exit 1

--- a/bin/bashvm-fetch
+++ b/bin/bashvm-fetch
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 fetch() {
-  if [[ -d "$BASHVM_HOME/src/bash-${1}" ]]; then
-    echo "The source of bash-${1} is already exists"
+  if [[ -z $force && -d "$BASHVM_HOME/src/bash-${bash_version}" ]]; then
+    echo "The source of bash-${bash_version} is already exists"
     return 0
   fi
 
   tmpfile=$(mktemp)
-  echo "Fetching bash-${1}..."
-  curl -o"$tmpfile"  --progress-bar "ftp://ftp.gnu.org/gnu/bash/bash-${1}.tar.gz" || exit 1
+  echo "Fetching bash-${bash_version}..."
+  curl -o"$tmpfile"  --progress-bar "ftp://ftp.gnu.org/gnu/bash/bash-${bash_version}.tar.gz" || exit 1
   tar zxf "$tmpfile" -C $BASHVM_HOME/src
   rm "$tmpfile"
 }
@@ -19,15 +19,31 @@ Usage: bashvm fetch <version>
 "
 }
 
-case "$1" in
---help)
+force=
+bash_version=
+
+while test $# != 0; do
+  case "$1" in
+  --help)
+    help
+    exit 0
+    ;;
+  -f|--force)
+    force=t
+    ;;
+  -*|--*)
+    die "Unrecognized option: $1"
+    ;;
+  *)
+    bash_version="${1#bash-}"
+    ;;
+  esac
   shift
+done
+
+if [ -z "$bash_version" ]; then
   help
-  ;;
--*|--*)
-  die "Unrecognized option: $1"
-  ;;
-*)
-  fetch ${1#bash-}
-  ;;
-esac
+  exit 1
+fi
+
+fetch

--- a/test/fetch/fetch_test.sh
+++ b/test/fetch/fetch_test.sh
@@ -2,7 +2,9 @@ source $(dirname $BASH_SOURCE)/../test_helper.sh
 
 setup() {
   tmpdir=$(mktemp -d)
-  mkdir $tmpdir/src
+  export BASHVM_HOME=$tmpdir
+
+  mkdir $BASHVM_HOME/src
 }
 
 teardown() {
@@ -10,16 +12,22 @@ teardown() {
 }
 
 testcase_fetch_valid_version() {
-  BASHVM_HOME=$tmpdir subject bashvm fetch 3.2
-  assert_true test -d "$tmpdir/src/bash-3.2"
+  subject bashvm fetch 3.2
+  assert_true test -d "$BASHVM_HOME/src/bash-3.2"
 }
 
 testcase_fetch_invalid_version() {
-  BASHVM_HOME=$tmpdir assert_false bashvm fetch su.shi
+  assert_false bashvm fetch su.shi
 }
 
 testcase_exit_when_source_already_exist() {
   mkdir -p $BASHVM_HOME/src/bash-9.9
   subject bashvm fetch 9.9
   assert_match 'already exists' "$stdout"
+}
+
+testcase_fetch_force() {
+  mkdir -p $BASHVM_HOME/src/bash-3.2
+  subject bashvm fetch --force 3.2
+  assert_true test -f "$BASHVM_HOME/src/bash-3.2/configure"
 }

--- a/test/fetch/fetch_test.sh
+++ b/test/fetch/fetch_test.sh
@@ -17,3 +17,9 @@ testcase_fetch_valid_version() {
 testcase_fetch_invalid_version() {
   BASHVM_HOME=$tmpdir assert_false bashvm fetch su.shi
 }
+
+testcase_exit_when_source_already_exist() {
+  mkdir -p $BASHVM_HOME/src/bash-9.9
+  subject bashvm fetch 9.9
+  assert_match 'already exists' "$stdout"
+}


### PR DESCRIPTION
When the source of bash version already exists in local directory, bashvm skips to fetch the source.  In order to ignore skipping, fetch with --force option.

```
bashvm fetch --force X.Y
```
